### PR TITLE
notification history

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -118,6 +118,19 @@ export default {
     });
     window.wails.Events.On("new_transaction", txObject => {
       this.$store.commit("updateTxHistory", txObject);
+      this.$store.commit("addTxNotification", 
+        {
+          id: Math.random(),
+          type:"transaction",
+          description:"Awaiting confirmation from mainnet", 
+          read: false,
+          tx: {
+            datetime: txObject.TS,
+            hash: txObject.Hash,
+            status: txObject.Status
+          }
+        }
+      );
     });
     window.wails.Events.On("tx_pending", txStatus => {
       this.$store.state.txInfo.txStatus = txStatus;

--- a/frontend/src/assets/sass/paper/_dropdown.scss
+++ b/frontend/src/assets/sass/paper/_dropdown.scss
@@ -32,9 +32,9 @@
     }
 
     .dropdown-item{
-      color: $font-color !important;
+      color: $font-color;
       font-size: $font-size-base;
-      padding: 0.625em 2.8125em 0.625em 0.9375em;
+      padding: 0.625em 0em 0.625em 0.9375em;
       clear: both;
       white-space: nowrap;
       width: 100%;
@@ -50,6 +50,19 @@
     }
     .dropdown-item a:focus{
       outline: 0 !important;
+    }
+    .dropdown-item.active {
+      background-color: #bfecfd;
+    }
+    .dropdown-item.inactive {
+      color: $dark-gray;
+      font-style: italic;
+    }
+
+    .dropdown-header-link {
+      margin-left: 0.875rem;
+      text-decoration: underline; 
+      color:#9A9A9A;
     }
 
     .btn-group.select &{
@@ -446,4 +459,17 @@
 .navbar-nav.mr-auto .dropdown-menu:after{
   left: 0.75em !important;
   right: auto;
+}
+
+.dropdown-menu {
+  left: -5rem;
+  width: 27.6rem;
+}
+
+.dropdown-header {
+  background-color: $pale-bg;
+}
+
+.dropup .dropdown-toggle:after, .dropdown .dropdown-toggle:after {
+  display: none;
 }

--- a/frontend/src/assets/sass/paper/_responsive.scss
+++ b/frontend/src/assets/sass/paper/_responsive.scss
@@ -30,7 +30,7 @@
     content: "";
     display: inline-block;
     position: absolute;
-    right: 0.75em;
+    right: 12.8rem;
     top: -0.6875em;
   }
   .navbar-nav > li > .dropdown-menu:after {
@@ -40,7 +40,7 @@
     content: "";
     display: inline-block;
     position: absolute;
-    right: 0.75em;
+    right: 12.8rem;
     top: -0.625em;
   }
 

--- a/frontend/src/layout/dashboard/TopNavbar.vue
+++ b/frontend/src/layout/dashboard/TopNavbar.vue
@@ -17,6 +17,63 @@
       <div class="collapse navbar-collapse">
         <ul class="navbar-nav ml-auto">
           <li class="nav-item">
+            <a class="nav-link" @click="test" style="cursor: pointer;">
+              <i class="fa fa-check"></i>TxEvent
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" @click="test2" style="cursor: pointer;">
+              <i class="fa fa-check"></i>SysEvent
+            </a>
+          </li>
+          <drop-down class="nav-item" title-classes="nav-link">
+            <template v-slot:title>
+              <i class="ti-bell"></i>
+              <span>
+                Notifications
+                <span v-if="(txNotificationCount + systemNotificationCount) > 0" class="badge badge-danger" style="width:0.875rem;">
+                  {{(txNotificationCount + systemNotificationCount)}}
+                </span>
+                <span v-else class="badge invisible" style="width:0.875rem;">0</span>
+              </span>
+            </template>
+            <div v-if="(txNotificationCount + systemNotificationCount) == 0" class="dropdown-item inactive text-center">
+              No new notifications available
+            </div>
+            <li class="dropdown-header" style="display: flex;" v-if="this.$store.state.notificationInfo.txNotifications.length > 0">
+              <div style="margin-right: auto;">Transactions</div>
+              <div class="dropdown-header-link" @click="markTxNotficationsAsRead">mark as read</div>
+              <div class="dropdown-header-link" @click="clearTxNotfications">clear</div>
+            </li>
+            <div v-for="n in this.$store.state.notificationInfo.txNotifications" v-bind:key="n.id" class="dropdown-item" 
+              :class="n.read ? 'inactive' : 'active'" style="display: flex;" @click="markTxNotificationAsRead(n)">
+              <div>
+                {{n.tx.datetime}} {{n.description}}
+                <p class="small">{{n.tx.hash}}</p>
+              </div>
+              <div style="margin-top: 0.45rem; margin-left: auto;">
+                <i v-if="n.tx.status === 'Complete'" class="fa fa-check"></i>
+                <i v-if="n.tx.status === 'Pending'" class="ti-timer"></i>
+                <i v-if="n.tx.status === 'Error'" class="fa fa-times"></i>
+              </div>
+            </div>
+            <li class="dropdown-header" style="display: flex;" v-if="this.$store.state.notificationInfo.systemNotifications.length > 0">
+              <div style="margin-right: auto;">System</div>
+              <div class="dropdown-header-link" @click="markSystemNotificationsAsRead">mark as read</div>
+              <div class="dropdown-header-link" @click="clearSystemNotfications">clear</div>
+            </li>
+            <div v-for="n in this.$store.state.notificationInfo.systemNotifications" v-bind:key="n.id" class="dropdown-item" 
+              :class="n.read ? 'inactive' : 'active'" style="display: flex;" @click="markSystemNotificationAsRead(n)">
+              <div>
+                <div>{{n.description}}</div>
+                <p class="small">...</p>
+              </div>
+              <div style="margin-top: 0.45rem; margin-left: auto;">
+                <i class="fa fa-exclamation-circle"></i>
+              </div>
+            </div>
+          </drop-down>
+          <li class="nav-item">
             <router-link class="nav-link" to="/settings">
               <i class="ti-settings"></i>
               <p class="nav-item">SETTINGS</p>
@@ -40,6 +97,32 @@ export default {
     routeName() {
       const { name } = this.$route;
       return this.capitalizeFirstLetter(name);
+    },
+    txNotificationCount () {
+      let unreadTxNotifications = this.$store.state.notificationInfo.txNotifications.filter(
+        function (e) {return e.read == false;}
+      );
+      return unreadTxNotifications.length;
+    },
+    systemNotificationCount () {
+      let unreadSystemNotifications = this.$store.state.notificationInfo.systemNotifications.filter(
+        function (e) {return e.read == false;}
+      );
+      return unreadSystemNotifications.length;
+    }
+  },
+  watch: {
+    txNotificationCount (newCount, oldCount) {
+      if (newCount > oldCount) {
+        let latestItem = this.$store.state.notificationInfo.txNotifications[this.$store.state.notificationInfo.txNotifications.length - 1]
+        this.showNotification(latestItem.type, latestItem.description, "info");
+      }
+    },
+    systemNotificationCount (newCount, oldCount) {
+      if (newCount > oldCount) {
+        let latestItem = this.$store.state.notificationInfo.systemNotifications[this.$store.state.notificationInfo.systemNotifications.length - 1]
+        this.showNotification(latestItem.type, latestItem.description, "info");
+      }
     }
   },
   data() {
@@ -85,6 +168,67 @@ export default {
     },
     hideSidebar() {
       this.$sidebar.displaySidebar(false);
+    },
+    showNotification(title, message, type) {
+      setTimeout(() => {
+        this.$notifications.clear();
+      }, 3000);
+      this.$notify({
+        title: title,
+        message: message,
+        icon: "fa fa-bell",
+        horizontalAlign: "right",
+        verticalAlign: "bottom",
+        type: type,
+        onClick: () => {
+          this.$notifications.clear();
+        }
+      });
+    },
+    markTxNotificationAsRead(notification) {
+      notification.read = true;
+      this.$store.commit("updateTxNotification", notification);
+    },
+    markTxNotficationsAsRead() {
+      this.$store.commit("updateTxNotificationsAsRead")
+    },
+    clearTxNotfications() {
+      this.$store.commit("deleteTxNotifications")
+    },
+    markSystemNotificationAsRead(notification) {
+      notification.read = true;
+      this.$store.commit("updateSystemNotification", notification);
+    },
+    markSystemNotificationsAsRead() {
+      this.$store.commit("updateSystemNotificationsAsRead")
+    },
+    clearSystemNotfications() {
+      this.$store.commit("deleteSystemNotifications")
+    },
+    test() {
+      this.$store.commit("addTxNotification", 
+        {
+          id: Math.random(),
+          type:"transaction",
+          description:"Awaiting confirmation from mainnet", 
+          read: false,
+          tx: {
+            datetime: "Mon Jan _2 15:04:05 2006",
+            hash: "7ed02e54dd824ce425752c9c03bdd27f11c05ecd5c36741a311d8020759f54e9",
+            status: "Pending"
+          }
+        }
+      );
+    },
+    test2() {
+      this.$store.commit("addSystemNotification", 
+        {
+          id: Math.random(),
+          type:"system",
+          description:"Some system error has occured.", 
+          read: false
+        }
+      );
     }
   }
 };

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -48,6 +48,10 @@ export const store = new Vuex.Store({
             txHistory: [],
             txStatus: "Complete"
         },
+        notificationInfo: {
+            txNotifications: [],
+            systemNotifications: []
+        },
         counters: {
             blockCounter: 5,
             tokenCounter: 30,
@@ -76,14 +80,40 @@ export const store = new Vuex.Store({
         }
     },
     mutations: {
-        updateTxHistory(state, tx) {
+        addTxHistory(state, tx) {
             state.txInfo.txHistory.unshift(tx)
         },
         updateFullTxHistory(state, txHistoryUpdated) {
-            
             state.txInfo.txHistory = txHistoryUpdated
-            
         },
+        addTxNotification(state, notification) {
+            state.notificationInfo.txNotifications.unshift(notification)
+        },
+        updateTxNotification (state, notification) {
+            let foundIndex = state.notificationInfo.txNotifications.findIndex(x => x.id == notification.id);
+            state.notificationInfo.txNotifications[foundIndex] = notification;
+        },
+        updateTxNotificationsAsRead (state) {
+            state.notificationInfo.txNotifications.filter(n => n.read == false)
+              .forEach(f => f.read = true);
+        },
+        deleteTxNotifications (state) {
+            state.notificationInfo.txNotifications = [];
+        },
+        addSystemNotification(state, notification) {
+            state.notificationInfo.systemNotifications.unshift(notification)
+        },
+        updateSystemNotification (state, notification) {
+            let foundIndex = state.notificationInfo.systemNotifications.findIndex(x => x.id == notification.id);
+            state.notificationInfo.systemNotifications[foundIndex] = notification;
+        },
+        updateSystemNotificationsAsRead (state) {
+              state.notificationInfo.systemNotifications.filter(n => n.read == false)
+              .forEach(f => f.read = true);
+        },
+        deleteSystemNotifications (state) {
+            state.notificationInfo.systemNotifications = [];
+        }
     }
 
 })


### PR DESCRIPTION
When a new notification is detected in the store it automatically displays a notification and marks it as unread for the new notification section in the topnavbar. 

-- Currently only generates a notification on the [new_transaction] event, awaiting testnet to test it
-- Added test-buttons to try it out while the testnet is unavailable and to gather some feedback
-- Request: if this approach is ok, could the [tx_in_transit] / [tx_pending] events also return the txObject or otherwise the date and hash so that they can display consistently in the new notification section?