### PR TITLE
Set keystore path only from login / create

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -43,17 +43,16 @@ type WalletApplication struct {
 		}
 	}
 	paths struct {
-		HomeDir        string
-		DAGDir         string
-		TMPDir         string
-		EncryptedDir   string
-		EncPrivKeyFile string
-		EmptyTXFile    string
-		PrevTXFile     string
-		LastTXFile     string
-		AddressFile    string
-		ImageDir       string
-		Java           string
+		HomeDir      string
+		DAGDir       string
+		TMPDir       string
+		EncryptedDir string
+		EmptyTXFile  string
+		PrevTXFile   string
+		LastTXFile   string
+		AddressFile  string
+		ImageDir     string
+		Java         string
 	}
 	KeyStoreAccess      bool
 	TransactionFinished bool
@@ -146,7 +145,6 @@ func (a *WalletApplication) initDirectoryStructure() error {
 	a.paths.HomeDir = user.HomeDir             // Home directory of the user
 	a.paths.DAGDir = a.paths.HomeDir + "/.dag" // DAG directory for configuration files and wallet specific data
 	a.paths.TMPDir = a.paths.DAGDir + "/tmp"
-	a.paths.EncPrivKeyFile = a.paths.EncryptedDir
 	a.paths.LastTXFile = a.paths.TMPDir + "/last_tx"
 	a.paths.PrevTXFile = a.paths.TMPDir + "/prev_tx"
 	a.paths.EmptyTXFile = a.paths.TMPDir + "/genesis_tx"

--- a/backend/assemblywrapper.go
+++ b/backend/assemblywrapper.go
@@ -59,7 +59,7 @@ func (a *WalletApplication) WalletKeystoreAccess() bool {
 		a.sendError("Unable to pipe STDOUT, Reason: ", err)
 	}
 	os.Stdout = w
-	err = a.runWalletCMD("wallet", "show-address", "--keystore="+a.paths.EncPrivKeyFile, "--alias="+a.wallet.WalletAlias, "--env_args=true")
+	err = a.runWalletCMD("wallet", "show-address", "--keystore="+a.wallet.KeyStorePath, "--alias="+a.wallet.WalletAlias, "--env_args=true")
 	if err != nil {
 		a.log.Warn("KeyStore Access Rejected!")
 		a.LoginError("Access Denied. Please make sure that you have typed in the correct credentials.")
@@ -104,7 +104,7 @@ func (a *WalletApplication) GenerateDAGAddress() string {
 	}
 	os.Stdout = w
 
-	err = a.runWalletCMD("wallet", "show-address", "--keystore="+a.paths.EncPrivKeyFile, "--alias="+a.wallet.WalletAlias, "--env_args=true")
+	err = a.runWalletCMD("wallet", "show-address", "--keystore="+a.wallet.KeyStorePath, "--alias="+a.wallet.WalletAlias, "--env_args=true")
 	if err != nil {
 		a.sendError("Unable to generate wallet address. Reason:", err)
 		a.log.Errorf("Unable to generate wallet address. Reason: %s", err.Error())
@@ -187,7 +187,7 @@ func (a *WalletApplication) produceTXObject(amount int64, fee int64, address, ne
 	}
 
 	// newTX is the full command to sign a new transaction
-	err = a.runWalletCMD("wallet", "create-transaction", "--keystore="+a.paths.EncPrivKeyFile, "--normalized", "--alias="+a.wallet.WalletAlias, "--amount="+amountStr, "--fee="+feeNorm, "-d="+address, "-f="+newTX, "-p="+prevTX, "--env_args=true")
+	err = a.runWalletCMD("wallet", "create-transaction", "--keystore="+a.wallet.KeyStorePath, "--normalized", "--alias="+a.wallet.WalletAlias, "--amount="+amountStr, "--fee="+feeNorm, "-d="+address, "-f="+newTX, "-p="+prevTX, "--env_args=true")
 	if err != nil {
 		a.sendError("Unable to send transaction. Don't worry, your funds are safe. Please report this issue. Reason: ", err)
 		a.log.Errorln("Unable to send transaction. Reason: ", err)
@@ -200,7 +200,7 @@ func (a *WalletApplication) produceTXObject(amount int64, fee int64, address, ne
 // will create a new password protected encrypted keypair stored in user selected location
 // java -jar cl-keytool.jar --keystore testkey.p12 --alias alias --storepass storepass --keypass keypass
 func (a *WalletApplication) CreateEncryptedKeyStore() error {
-	err := a.runWalletCMD("keytool", "--keystore="+a.paths.EncPrivKeyFile, "--alias="+a.wallet.WalletAlias, "--env_args=true")
+	err := a.runWalletCMD("keytool", "--keystore="+a.wallet.KeyStorePath, "--alias="+a.wallet.WalletAlias, "--env_args=true")
 	if err != nil {
 		a.LoginError("Unable to write encrypted keys to filesystem.")
 		a.log.Errorf("Unable to write encrypted keys to filesystem. Reason: %s", err.Error())

--- a/backend/login.go
+++ b/backend/login.go
@@ -21,7 +21,9 @@ func (a *WalletApplication) LoginError(errMsg string) {
 func (a *WalletApplication) Login(keystorePath, keystorePassword, keyPassword, alias string) bool {
 
 	alias = strings.ToLower(alias)
-	a.wallet.WalletAlias = alias
+	a.wallet = models.Wallet{
+		KeyStorePath: keystorePath,
+		WalletAlias:  alias}
 
 	if runtime.GOOS == "windows" && !a.javaInstalled() {
 		a.LoginError("Unable to detect your Java path. Please make sure that Java has been installed.")
@@ -105,33 +107,34 @@ func (a *WalletApplication) LogOut() bool {
 
 // ImportKey is called from the frontend when browsing the fs for a keyfile
 func (a *WalletApplication) ImportKey() string {
-	a.paths.EncPrivKeyFile = a.RT.Dialog.SelectFile()
-	if a.paths.EncPrivKeyFile == "" {
+	var keyfile = a.RT.Dialog.SelectFile()
+	if keyfile == "" {
 		a.LoginError("Access Denied. No key path detected.")
 		return ""
 	}
 
-	if a.paths.EncPrivKeyFile[len(a.paths.EncPrivKeyFile)-4:] != ".p12" {
+	if keyfile[len(keyfile)-4:] != ".p12" {
 		a.LoginError("Access Denied. Not a key file.")
 		return ""
 	}
-	a.log.Info("Path to imported key: " + a.paths.EncPrivKeyFile)
-	return a.paths.EncPrivKeyFile
+	a.log.Info("Path to imported key: " + keyfile)
+	return keyfile
 }
 
 // SelectDirToStoreKey is called from the FE when creating a new keyfile
 func (a *WalletApplication) SelectDirToStoreKey() string {
-	a.paths.EncPrivKeyFile = a.RT.Dialog.SelectSaveFile()
 
-	if len(a.paths.EncPrivKeyFile) <= 0 {
+	var keyfile = a.RT.Dialog.SelectSaveFile()
+
+	if len(keyfile) <= 0 {
 		a.LoginError("No valid path were provided. Please try again.")
 		return ""
 	}
-	if a.paths.EncPrivKeyFile[len(a.paths.EncPrivKeyFile)-4:] != ".p12" {
-		a.paths.EncPrivKeyFile = a.paths.EncPrivKeyFile + ".p12"
-		return a.paths.EncPrivKeyFile
+	if keyfile[len(keyfile)-4:] != ".p12" {
+		keyfile = keyfile + ".p12"
+		return keyfile
 	}
-	return a.paths.EncPrivKeyFile
+	return keyfile
 }
 
 // GenerateSaltedHash converts plain text to a salted hash


### PR DESCRIPTION
Only stores it on the actual Wallet. No longer also stores it on WalletApplication (EncPrivKeyFile) which was done when selecting a key file.

In Wails bridged-mode (i.e. when testing in the browser) its now easy to workaround the dialog not working and perform the complete login pageflow by setting the keystorePath in the wallet.js vuex module