### PR TITLE
Fix send max amount

### DIFF
--- a/backend/assemblywrapper.go
+++ b/backend/assemblywrapper.go
@@ -169,23 +169,10 @@ func (a *WalletApplication) produceTXObject(amount int64, fee int64, address, ne
 
 	// Convert to string
 	amountStr := strconv.FormatInt(amount, 10)
-	// feeStr := strconv.FormatInt(fee, 10)
-
-	// amountNorm, err := normalizeAmounts(amount)
-	// if err != nil {
-	// 	a.log.Errorln("Unable to normalize amounts when producing tx object. Reason: ", err)
-	// 	a.sendError("Unable to send transaction. Don't worry, your funds are safe. Please report this issue. Reason: ", err)
-	// 	return
-	// }
-	feeNorm, err := normalizeAmounts(fee)
-	if err != nil {
-		a.log.Errorln("Unable to normalize amounts when producing tx object. Reason: ", err)
-		a.sendError("Unable to send transaction. Don't worry, your funds are safe. Please report this issue. Reason: ", err)
-		return
-	}
+	feeStr := strconv.FormatInt(fee, 10)
 
 	// newTX is the full command to sign a new transaction
-	err = a.runWalletCMD("wallet", "create-transaction", "--keystore="+a.wallet.KeyStorePath, "--normalized", "--alias="+a.wallet.WalletAlias, "--amount="+amountStr, "--fee="+feeNorm, "-d="+address, "-f="+newTX, "-p="+prevTX, "--env_args=true")
+	err := a.runWalletCMD("wallet", "create-transaction", "--keystore="+a.wallet.KeyStorePath, "--normalized", "--alias="+a.wallet.WalletAlias, "--amount="+amountStr, "--fee="+feeStr, "-d="+address, "-f="+newTX, "-p="+prevTX, "--env_args=true")
 	if err != nil {
 		a.sendError("Unable to send transaction. Don't worry, your funds are safe. Please report this issue. Reason: ", err)
 		a.log.Errorln("Unable to send transaction. Reason: ", err)

--- a/backend/dashboard.go
+++ b/backend/dashboard.go
@@ -281,11 +281,11 @@ func (a *WalletApplication) pricePoller() {
 
 					totalCurrencyBalance := 0.0
 					if a.wallet.Currency == "USD" {
-						totalCurrencyBalance = float64(a.wallet.Balance) * a.wallet.TokenPrice.DAG.USD
+						totalCurrencyBalance = float64(a.wallet.Balance/1e8) * a.wallet.TokenPrice.DAG.USD
 					} else if a.wallet.Currency == "EUR" {
-						totalCurrencyBalance = float64(a.wallet.Balance) * a.wallet.TokenPrice.DAG.EUR
+						totalCurrencyBalance = float64(a.wallet.Balance/1e8) * a.wallet.TokenPrice.DAG.EUR
 					} else if a.wallet.Currency == "BTC" {
-						totalCurrencyBalance = float64(a.wallet.Balance) * a.wallet.TokenPrice.DAG.BTC
+						totalCurrencyBalance = float64(a.wallet.Balance/1e8) * a.wallet.TokenPrice.DAG.BTC
 					}
 					a.RT.Events.Emit("totalValue", a.wallet.Currency, totalCurrencyBalance)
 

--- a/backend/transactions.go
+++ b/backend/transactions.go
@@ -60,8 +60,8 @@ type Transaction struct {
 
 // TriggerTXFromFE will initate a new transaction triggered from the frontend.
 func (a *WalletApplication) TriggerTXFromFE(amount float64, fee float64, address string) bool {
-	amountConverted := int64(amount * 1e8)
-	feeConverted := int64(fee * 1e8)
+	amountConverted := int64(amount)
+	feeConverted := int64(fee)
 
 	a.PrepareTransaction(amountConverted, feeConverted, address)
 	for !a.TransactionFinished {
@@ -82,9 +82,9 @@ func (a *WalletApplication) PrepareTransaction(amount int64, fee int64, address 
 		return
 	}
 
-	if amount+fee > int64(balance*1e8) {
+	if amount+fee > int64(balance) {
 		a.log.Warnf("Trying to send: %d", amount+fee)
-		a.log.Warnf("Insufficient Balance: %d", int64(balance*1e8))
+		a.log.Warnf("Insufficient Balance: %d", int64(balance))
 		a.sendWarning("Insufficent Balance.")
 		a.TransactionFailed = true
 		return

--- a/backend/utils.go
+++ b/backend/utils.go
@@ -90,12 +90,6 @@ func (a *WalletApplication) detectJavaPath() {
 	}
 }
 
-//normalizeAmounts takes amount/fee in int64 and normalizes it. Example: passing 821500000000 will return 8215
-func normalizeAmounts(i int64) (string, error) {
-	f := fmt.Sprintf("%.8f", float64(i)/1e8)
-	return f, nil
-}
-
 // TempFileName creates temporary file names for the transaction files
 func (a *WalletApplication) TempFileName(prefix string) string {
 	randBytes := make([]byte, 16)

--- a/backend/wallet.go
+++ b/backend/wallet.go
@@ -3,12 +3,10 @@ package app
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -530,17 +528,7 @@ func (a *WalletApplication) GetTokenBalance() (float64, error) {
 		return 0, err
 	}
 
-	f := fmt.Sprintf("%.2f", b/1e8) // Reverse normalized float
+	a.log.Infoln("Returning the following balance: ", b)
 
-	a.log.Infoln("Normalized the following balance: ", f)
-
-	balance, err := strconv.ParseFloat(f, 64)
-	if err != nil {
-		a.log.Warnln("Unable to type cast string to float for token balance poller. Check your internet connectivity")
-		return 0, err
-	}
-
-	a.log.Infoln("Returning the following balance: ", balance)
-
-	return balance, nil
+	return b, nil
 }

--- a/frontend/src/assets/sass/paper/_themes.scss
+++ b/frontend/src/assets/sass/paper/_themes.scss
@@ -41,6 +41,7 @@ $themes: (
     walletAddressColor: $medium-dark-gray,
 
     popupBackgroundColor: $bg-nude,
+    popupTextColor: #272727,
 
     primaryColor: $primary-color,
     primaryStatesColor: $primary-states-color,
@@ -97,6 +98,7 @@ $themes: (
     walletAddressColor: #BCBCBC,
 
     popupBackgroundColor: #272727,
+    popupTextColor: $dark-gray,
 
     primaryColor: $primary-color-dark,
     primaryStatesColor: $primary-states-color-dark,

--- a/frontend/src/assets/sass/paper/sweetalert2.scss
+++ b/frontend/src/assets/sass/paper/sweetalert2.scss
@@ -10,9 +10,28 @@ $swal2-confirm-button-font-size: 0.75rem;
 $swal2-cancel-button-font-size: 0.75rem;
 $swal2-confirm-button-background-color: $primary-color;
 
-.swal2-popup.swal2-modal.swal2-show {
+.swal2-popup.swal2-modal {
   @include themed() {
     background: t('popupBackgroundColor');
+  }
+}
+
+#swal2-title {
+  @include themed() {
+    color: t('popupTextColor');
+  }
+}
+
+#swal2-content {
+  @include themed() {
+    color: t('popupTextColor');
+  }
+}
+
+#swal2-validation-message {
+  @include themed() {
+    background: t('cardTableColor');
+    border-color: t('inputBorderColor');
   }
 }
 

--- a/frontend/src/components/Timeline.vue
+++ b/frontend/src/components/Timeline.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div v-if="value.length">
-      <div class="total-value text-center">{{availableBalance | asCurrency('DAG-short')}} $DAG</div>
+      <div class="total-value text-center">{{availableBalance | normalizeDAG | asCurrency('DAG-short')}} $DAG</div>
       <ul class="timeline">
         <li class="timeline-inverted d-flex" v-for="tx in value" v-bind:key="tx.ID">
           <div class="timeline-label">

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -8,7 +8,7 @@
           </div>
           <div class="numbers text-center text-overflow" slot="content">
             <p>DAG</p>
-            {{tokenAmount | asCurrency('DAG')}}
+            {{tokenAmount | normalizeDAG | asCurrency('DAG')}}
           </div>
           <div class="stats" slot="footer">
             <i class="ti-timer"></i>
@@ -171,12 +171,6 @@ export default {
       testingCodeToCopy.setAttribute("type", "hidden");
       window.getSelection().removeAllRanges();
     },
-    getTokens: function() {
-      var self = this;
-      window.backend.retrieveTokenAmount().then(result => {
-        self.tokenAmount = result;
-      });
-    },
     addNotification(verticalAlign, horizontalAlign, color, copied) {
       setTimeout(() => {
         this.$notifications.clear();
@@ -221,6 +215,9 @@ export default {
         });
       }
       return formatter.format(value).replace(/XBT/,'₿');
+    },
+    normalizeDAG: function (value) {
+      return (value / 1e8).toFixed(8).replace(/\.?0+$/, "");
     }
   },
 

--- a/frontend/src/pages/UserProfile/EditProfileForm.vue
+++ b/frontend/src/pages/UserProfile/EditProfileForm.vue
@@ -100,9 +100,6 @@ export default {
     ...mapState("app", ["version", "uiVersion"]),
     ...mapState("wallet", [
       "address",
-      "availableBalance",
-      "nonce",
-      "totalBalance",
       "alias",
       "keystorePath",
       "termsOfService",

--- a/frontend/src/pages/UserProfile/EditProfileForm.vue
+++ b/frontend/src/pages/UserProfile/EditProfileForm.vue
@@ -17,7 +17,7 @@
           <div class="col-md-12">
             <fg-input
               type="text"
-              label="Available Balance"
+              label="Available Balance (not normalized)"
               :disabled="true"
               placeholder="0"
               v-model="availableBalance"
@@ -39,7 +39,7 @@
           <div class="col-md-12">
             <fg-input
               type="text"
-              label="Total Balance"
+              label="Total Balance (not normalized)"
               :disabled="true"
               placeholder="0"
               v-model="totalBalance"

--- a/frontend/src/pages/UserProfile/EditProfileForm.vue
+++ b/frontend/src/pages/UserProfile/EditProfileForm.vue
@@ -17,32 +17,10 @@
           <div class="col-md-12">
             <fg-input
               type="text"
-              label="Available Balance (not normalized)"
+              label="Available Balance"
               :disabled="true"
               placeholder="0"
-              v-model="availableBalance"
-            ></fg-input>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-12">
-            <fg-input
-              type="text"
-              label="Nonce"
-              :disabled="true"
-              placeholder="0"
-              v-model="nonce"
-            ></fg-input>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-12">
-            <fg-input
-              type="text"
-              label="Total Balance (not normalized)"
-              :disabled="true"
-              placeholder="0"
-              v-model="totalBalance"
+              v-model="getNormalizedAvailableBalance"
             ></fg-input>
           </div>
         </div>
@@ -108,18 +86,28 @@
 </template>
 
 <script>
-import {mapState} from 'vuex'
+import { mapState } from "vuex";
 export default {
   data() {
-    return {};
+    return {
+      normAvailableBalance: this.getNormalizedAvailableBalance() 
+    };
   },
   computed: {
-    ...mapState('app', ['version', 'uiVersion']),
-    ...mapState('wallet', [
-      'address', 'availableBalance', 'nonce', 'totalBalance', 
-      'alias', 'keystorePath', 'termsOfService'])
-
-  }
+    getNormalizedAvailableBalance () {
+      return this.$store.getters["wallet/getNormalizedAvailableBalance"];
+    },
+    ...mapState("app", ["version", "uiVersion"]),
+    ...mapState("wallet", [
+      "address",
+      "availableBalance",
+      "nonce",
+      "totalBalance",
+      "alias",
+      "keystorePath",
+      "termsOfService",
+    ]),    
+  },
 };
 </script>
 <style scoped lang="scss">

--- a/frontend/src/pages/UserProfile/UserCard.vue
+++ b/frontend/src/pages/UserProfile/UserCard.vue
@@ -26,7 +26,7 @@
           </h5>
         </div>
         <div class="col-4">
-          <h5>{{tokenAmount | asCurrency('DAG')}}
+          <h5>{{tokenAmount | normalizeDAG | asCurrency('DAG')}}
             <br>
             <small>DAG</small>
           </h5>
@@ -73,8 +73,11 @@ export default {
         });
       }
       return formatter.format(value).replace(/XBT/,'₿');
+    },
+    normalizeDAG: function (value) {
+      return (value / 1e8).toFixed(8).replace(/\.?0+$/, "");
     }
-  },
+  }
 };
 </script>
 <style scoped lang="scss">

--- a/frontend/src/store/modules/wallet.js
+++ b/frontend/src/store/modules/wallet.js
@@ -6,7 +6,6 @@ const getDefaultState = () => {
     tokenAmount: 0,
     totalBalance: 0,
     availableBalance: 0,
-    nonce: 0,
     currency: "USD",
     totalValue: 0.0,
     address: "N/A",

--- a/frontend/src/store/modules/wallet.js
+++ b/frontend/src/store/modules/wallet.js
@@ -20,6 +20,12 @@ const getDefaultState = () => {
 
 const state = getDefaultState()
 
+const getters = {
+  getNormalizedAvailableBalance: (state) => {
+    return (state.availableBalance / 1e8).toFixed(8).replace(/\.?0+$/, "");
+  }
+}
+
 const actions = {
   reset({ commit }) {
     commit('resetState')
@@ -70,7 +76,7 @@ const mutations = {
 export default {
   namespaced: true,
   state,
-  getters: {},
+  getters,
   actions,
   mutations
 }


### PR DESCRIPTION
The max amount (or any other amount) in a transaction from the frontend now uses the actual values already. Normalized values are only still used for display purposes. Previously, with the max. button the normalized max amount in the transaction could be slightly larger than the actual wallet balance which is not allowed.